### PR TITLE
feat: integrate AI/ML API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# go-sense
+# aimlapi-go
+
+Go client for the [AI/ML API](https://api.aimlapi.com/v1) which provides access to
+hundreds of models such as DeepSeek, Gemini, and ChatGPT.
+
+## Usage
+
+```go
+package main
+
+import "github.com/casibase/aimlapi-go"
+
+func main() {
+    client, _ := aimlapi.NewClient("API_KEY", "MyApp", "https://example.com")
+    _ = client // use the client
+}
+```
+

--- a/chat.go
+++ b/chat.go
@@ -1,48 +1,43 @@
-package openrouter
+package aimlapi
 
 import (
-	"context"
-	"errors"
-	"net/http"
+        "context"
+        "errors"
+        "net/http"
 )
 
-// Chat message role defined by the Sensa API.
+// Chat message role defined by the API.
 
 type ModelName string
 
 const (
-	ChatMessageRoleUser      = "user"
-	ChatMessageRoleSystem    = "system"
-	ChatMessageRoleAssistant = "assistant"
+        ChatMessageRoleUser      = "user"
+        ChatMessageRoleSystem    = "system"
+        ChatMessageRoleAssistant = "assistant"
 )
 
 var (
-	ErrChatCompletionStreamNotSupported = errors.New("streaming is not supported with this method, please use CreateChatCompletionStream") //nolint:lll
-	ErrCompletionUnsupportedModel       = errors.New("this model is not supported with this method")                                       //nolint:lll
+        ErrChatCompletionStreamNotSupported = errors.New("streaming is not supported with this method, please use CreateChatCompletionStream") //nolint:lll
 )
 
-// CreateChatCompletion — API call to Create a completion for the chat message.
+// CreateChatCompletion — API call to create a completion for the chat message.
 func (c *Client) CreateChatCompletion(
-	ctx context.Context,
-	request *ChatCompletionRequest,
+        ctx context.Context,
+        request *ChatCompletionRequest,
 ) (response *ChatCompletionResponse, err error) {
-	if request.Stream {
-		err = ErrChatCompletionStreamNotSupported
-		return
-	}
+        if request.Stream {
+                err = ErrChatCompletionStreamNotSupported
+                return
+        }
 
-	urlSuffix := "/chat/completions"
-	request.Model = wrapperModels[request.Model]
-	if !checkSupportsModel(request.Model) {
-		err = ErrCompletionUnsupportedModel
-		return
-	}
+        urlSuffix := "/chat/completions"
 
-	req, err := c.requestBuilder.Build(ctx, http.MethodPost, c.fullURL(urlSuffix), request)
-	if err != nil {
-		return
-	}
+        req, err := c.requestBuilder.Build(ctx, http.MethodPost, c.fullURL(urlSuffix), request)
+        if err != nil {
+                return
+        }
 
-	err = c.sendRequest(req, &response)
-	return
+        err = c.sendRequest(req, &response)
+        return
 }
+

--- a/chat_stream.go
+++ b/chat_stream.go
@@ -1,9 +1,9 @@
-package openrouter
+package aimlapi
 
 import (
-	"bufio"
-	"context"
-	utils "github.com/Lok-Lu/go-openrouter/internal"
+        "bufio"
+        "context"
+        utils "github.com/casibase/aimlapi-go/internal"
 )
 
 type ChatCompletionStream struct {
@@ -15,20 +15,15 @@ type ChatCompletionStream struct {
 // sent as data-only server-sent events as they become available, with the
 // stream terminated by a data: [DONE] message.
 func (c *Client) CreateChatCompletionStream(
-	ctx context.Context,
-	request *ChatCompletionRequest,
+        ctx context.Context,
+        request *ChatCompletionRequest,
 ) (stream *ChatCompletionStream, err error) {
-	urlSuffix := "/chat/completions"
-	request.Model = wrapperModels[request.Model]
-	if !checkSupportsModel(request.Model) {
-		err = ErrCompletionUnsupportedModel
-		return
-	}
-	request.Stream = true
-	req, err := c.newStreamRequest(ctx, "POST", urlSuffix, request)
-	if err != nil {
-		return
-	}
+        urlSuffix := "/chat/completions"
+        request.Stream = true
+        req, err := c.newStreamRequest(ctx, "POST", urlSuffix, request)
+        if err != nil {
+                return
+        }
 
 	resp, err := c.config.HTTPClient.Do(req) //nolint:bodyclose // body is closed in stream.Close()
 	if err != nil {

--- a/chat_test.go
+++ b/chat_test.go
@@ -1,4 +1,4 @@
-package openrouter
+package aimlapi
 
 import (
 	"context"
@@ -9,7 +9,7 @@ func TestClient_CreateChatCompletion(t *testing.T) {
 	client, _ := NewClient("", "", "")
 
 	req := &ChatCompletionRequest{
-		Model: "claude-2",
+		Model: ModelGPT4,
 		Messages: []ChatCompletionMessage{
 			{
 				Role:    ChatMessageRoleSystem,

--- a/client.go
+++ b/client.go
@@ -1,10 +1,10 @@
-package openrouter
+package aimlapi
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
-	utils "github.com/Lok-Lu/go-openrouter/internal"
+	utils "github.com/casibase/aimlapi-go/internal"
 	"io"
 	"net/http"
 )

--- a/config.go
+++ b/config.go
@@ -1,16 +1,16 @@
-package openrouter
+package aimlapi
 
 import (
 	"net/http"
 )
 
 const (
-	routerAPIURLv1                 = "https://openrouter.ai/api/v1"
+	aimlAPIURLv1                   = "https://api.aimlapi.com/v1"
 	defaultEmptyMessagesLimit uint = 300
 )
 
 // ClientConfig is a configuration of a client.
-// XTitle、HttpRefer your own site url
+// authToken is your API key
 type ClientConfig struct {
 	authToken          string
 	XTitle             string
@@ -23,10 +23,10 @@ type ClientConfig struct {
 func DefaultConfig(auth, xTitle, httpReferer string) (ClientConfig, error) {
 	return ClientConfig{
 		authToken:          auth,
-		HTTPClient:         &http.Client{},
 		XTitle:             xTitle,
 		HttpReferer:        httpReferer,
-		BaseURL:            routerAPIURLv1,
+		HTTPClient:         &http.Client{},
+		BaseURL:            aimlAPIURLv1,
 		EmptyMessagesLimit: defaultEmptyMessagesLimit,
 	}, nil
 }

--- a/error.go
+++ b/error.go
@@ -1,4 +1,4 @@
-package openrouter
+package aimlapi
 
 import (
 	"encoding/json"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/Lok-Lu/go-openrouter
-go 1.19
+module github.com/casibase/aimlapi-go
 
+go 1.19

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/Lok-Lu/go-sense v0.0.0-20230725061455-4dd7a309233f h1:89hRut3MsEurlD0XFNuTdJ77jrF7ATvaC2uG7ohSdS0=
-github.com/Lok-Lu/go-sense v0.0.0-20230725061455-4dd7a309233f/go.mod h1:eRLP0PAv6OKI8x+HLjFtuo4fGRPu0y7H8prnvV25s2c=

--- a/stream_reader.go
+++ b/stream_reader.go
@@ -1,14 +1,14 @@
-package openrouter
+package aimlapi
 
 import (
-	"bufio"
-	"bytes"
-	"errors"
-	"fmt"
-	"io"
-	"net/http"
+        "bufio"
+        "bytes"
+        "errors"
+        "fmt"
+        "io"
+        "net/http"
 
-	utils "github.com/Lok-Lu/go-openrouter/internal"
+        utils "github.com/casibase/aimlapi-go/internal"
 )
 
 var (

--- a/types.go
+++ b/types.go
@@ -1,98 +1,52 @@
-package openrouter
+package aimlapi
 
 const (
-	GooglePalm2CodeChatBison = "google/palm-2-codechat-bison"
-	GooglePalm2ChatBison     = "google/palm-2-chat-bison"
-	OpenaiGpt35Turbo         = "openai/gpt-3.5-turbo"
-	OpenaiGpt35Turbo16k      = "openai/gpt-3.5-turbo-16k"
-	OpenaiGpt4               = "openai/gpt-4"
-	OpenaiGpt432K            = "openai/gpt-4-32k"
-	AnthropicClaude2         = "anthropic/claude-2"
-	AnthropicClaudeInstantV1 = "anthropic/claude-instant-v1"
-	MetaLlamaLlama213bChat   = "meta-llama/llama-2-13b-chat"
-	MetaLlamaLlama270bChat   = "meta-llama/llama-2-70b-chat"
-	Palm2CodeChatBison       = "palm-2-codechat-bison"
-	Palm2ChatBison           = "palm-2-chat-bison"
-	Gpt35Turbo               = "gpt-3.5-turbo"
-	Gpt35Turbo16k            = "gpt-3.5-turbo-16k"
-	Gpt4                     = "gpt-4"
-	G432K                    = "gpt-4-32k"
-	Claude2                  = "claude-2"
-	ClaudeInstantV1          = "claude-instant-v1"
-	Llama213bChat            = "llama-2-13b-chat"
-	Llama270bChat            = "llama-2-70b-chat"
+        ModelDeepSeekChat = "deepseek-chat"
+        ModelGeminiPro    = "gemini-pro"
+        ModelGPT35Turbo   = "gpt-3.5-turbo"
+        ModelGPT4         = "gpt-4"
 )
-
-var (
-	enableModels = map[string]bool{
-		GooglePalm2CodeChatBison: true,
-		GooglePalm2ChatBison:     true,
-		OpenaiGpt35Turbo:         true,
-		OpenaiGpt35Turbo16k:      true,
-		OpenaiGpt4:               true,
-		OpenaiGpt432K:            true,
-		AnthropicClaude2:         true,
-		AnthropicClaudeInstantV1: true,
-		MetaLlamaLlama213bChat:   true,
-		MetaLlamaLlama270bChat:   true,
-	}
-	wrapperModels = map[string]string{
-		Palm2CodeChatBison: GooglePalm2CodeChatBison,
-		Palm2ChatBison:     GooglePalm2ChatBison,
-		Gpt35Turbo:         OpenaiGpt35Turbo,
-		Gpt35Turbo16k:      OpenaiGpt35Turbo16k,
-		Gpt4:               OpenaiGpt4,
-		G432K:              OpenaiGpt432K,
-		Claude2:            AnthropicClaude2,
-		ClaudeInstantV1:    AnthropicClaudeInstantV1,
-		Llama213bChat:      MetaLlamaLlama213bChat,
-		Llama270bChat:      MetaLlamaLlama270bChat,
-	}
-)
-
-func checkSupportsModel(model string) bool {
-	return enableModels[model]
-}
 
 type ChatCompletionMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+        Role    string `json:"role"`
+        Content string `json:"content"`
 }
 
 // ChatCompletionRequest represents a request structure for chat completion API.
 type ChatCompletionRequest struct {
-	Model       string                  `json:"model"`
-	Messages    []ChatCompletionMessage `json:"messages"`
-	MaxTokens   int                     `json:"max_tokens,omitempty"`
-	Stream      bool                    `json:"stream,omitempty"`
-	Temperature *float32                `json:"temperature,omitempty"`
-	TopP        *float32                `json:"top_p,omitempty"`
-	TopK        *uint                   `json:"top_k,omitempty"`
+        Model       string                  `json:"model"`
+        Messages    []ChatCompletionMessage `json:"messages"`
+        MaxTokens   int                     `json:"max_tokens,omitempty"`
+        Stream      bool                    `json:"stream,omitempty"`
+        Temperature *float32                `json:"temperature,omitempty"`
+        TopP        *float32                `json:"top_p,omitempty"`
+        TopK        *uint                   `json:"top_k,omitempty"`
 }
 
 type Index struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+        Role    string `json:"role"`
+        Content string `json:"content"`
 }
 
 type ChatCompletionChoice struct {
-	Message      Index  `json:"message,omitempty"`
-	FinishReason string `json:"finish_reason,omitempty"`
-	Delta        Index  `json:"delta,omitempty"`
-	Index        uint   `json:"index,omitempty"`
+        Message      Index  `json:"message,omitempty"`
+        FinishReason string `json:"finish_reason,omitempty"`
+        Delta        Index  `json:"delta,omitempty"`
+        Index        uint   `json:"index,omitempty"`
 }
 
 // ChatCompletionResponse represents a response structure for chat completion API.
 type ChatCompletionResponse struct {
-	ID      string                 `json:"id,omitempty"`
-	Object  string                 `json:"object,omitempty"`
-	Created int64                  `json:"created,omitempty"`
-	Model   string                 `json:"model"`
-	Choices []ChatCompletionChoice `json:"choices"`
-	//Usage   Usage                  `json:"usage,omitempty"`
+        ID      string                 `json:"id,omitempty"`
+        Object  string                 `json:"object,omitempty"`
+        Created int64                  `json:"created,omitempty"`
+        Model   string                 `json:"model"`
+        Choices []ChatCompletionChoice `json:"choices"`
+        //Usage   Usage                  `json:"usage,omitempty"`
 }
 
 type Usage struct {
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
+        CompletionTokens int `json:"completion_tokens"`
+        TotalTokens      int `json:"total_tokens"`
 }
+


### PR DESCRIPTION
## Summary
- replace OpenRouter code with AI/ML API client
- add basic model constants and chat completion helpers
- document usage and restore optional X-Title and HTTP-Referer headers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a5c412e0208329ab9e00db57171a3a